### PR TITLE
No longer retries enrollment if no HTTP authentication is provided

### DIFF
--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -1046,7 +1046,6 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
     char *token = NULL;
     char user[MAX_UIDPWD];
     char pwd[MAX_UIDPWD];
-    int valid_token; //flag determines if token is valid or not
     
     hdr_len = (int) strnlen(hdr, EST_HTTP_REQ_TOTAL_LEN);
     if (hdr_len == EST_HTTP_REQ_TOTAL_LEN) {
@@ -1188,7 +1187,7 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
          */
         if (auth_credentials.auth_token == NULL) {
             EST_LOG_ERR("Requested token credentials, but application did not provide any.");
-            token = ""; //error check here -- MD
+            token = "";
         } else {
 
             /*
@@ -2730,7 +2729,7 @@ EST_ERROR est_client_enroll_csr (EST_CTX *ctx, X509_REQ *csr, int *pkcs7_len, EV
 	/*
 	 * Do a sanity check on the CSR
 	*/
-      rv = est_client_check_csr(csr); 
+        rv = est_client_check_csr(csr); 
 	if (EST_ERR_NONE != rv) {
 	    return (rv);
 	}

--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -1070,7 +1070,7 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
 
 	    /*
 	     *If valid userID and password are returned by the application continue building
-	     *the HTTP auth header. Otherwise, point the header to a NULL string since the the
+	     *the HTTP auth header. Otherwise, point the header to a NULL string since
 	     *it is not capable of Basic/Digest authentication 
 	     */
 	    if (user[0] == '\0' || pwd[0] == '\0'){
@@ -1093,7 +1093,7 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
         }				    
 	  
 	  /*
-	   * base64 encode the combined string and buld the HTTP auth header
+	   * base64 encode the combined string and build the HTTP auth header
 	   */
 	  est_base64_encode((const unsigned char *)both, strnlen(both, 2*MAX_UIDPWD), both_b64);
 	  snprintf(hdr + hdr_len, EST_HTTP_REQ_TOTAL_LEN-hdr_len,

--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -1046,6 +1046,7 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
     char *token = NULL;
     char user[MAX_UIDPWD];
     char pwd[MAX_UIDPWD];
+    int valid_token; //flag determines if token is valid or not
     
     hdr_len = (int) strnlen(hdr, EST_HTTP_REQ_TOTAL_LEN);
     if (hdr_len == EST_HTTP_REQ_TOTAL_LEN) {
@@ -1055,23 +1056,33 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
     
     switch (ctx->auth_mode) {
     case AUTH_BASIC:
-        snprintf(both, MAX_UIDPWD*2+2, "%s:%s", ctx->userid,
-                 ctx->password);
         /*
          * make sure we have both parts of the credentials to send.  If we do,
          * then we're operating in the original mode where the app layer
          * provides them up front before they're needed.  If not, then we can
          * now go ask for them from the app layer.
          */
-        if (ctx->userid[0] == '\0' || ctx->password[0] == '\0') {
+        if (ctx->userid[0] == '\0' && ctx->password[0] == '\0') {
 
             memset(user, 0, MAX_UIDPWD);
             memset(pwd, 0, MAX_UIDPWD);
             
             est_client_retrieve_credentials(ctx, ctx->auth_mode, user, pwd);
+
+	    /*
+	     *If valid userID and password are returned by the application continue building
+	     *the HTTP auth header. Otherwise, point the header to a NULL string since the the
+	     *it is not capable of Basic/Digest authentication 
+	     */
+	    if (user[0] == '\0' || pwd[0] == '\0'){
+	      /*Force hdr to a null string */
+	      EST_LOG_ERR("No User ID or Password was provided, not trying another enrollment attempt.");
+	      memset(hdr, 0, EST_HTTP_REQ_TOTAL_LEN);	  
+	      break;
+	    }
             
             /*
-             * regardless of what comes back, build the string containing both
+             * If a user ID and password are returned, build the string containing both
              */            
             snprintf(both, MAX_UIDPWD*2+2, "%s:%s", user, pwd);
         } else {
@@ -1080,14 +1091,16 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
              */
             snprintf(both, MAX_UIDPWD*2+2, "%s:%s", ctx->userid,
                      ctx->password);
-        }        
-        /*
-         * base64 encode the combined string and buld the HTTP auth header
-         */
-        est_base64_encode((const unsigned char *)both, strnlen(both, 2*MAX_UIDPWD), both_b64);
-        snprintf(hdr + hdr_len, EST_HTTP_REQ_TOTAL_LEN-hdr_len,
-                 "Authorization: Basic %s\r\n", both_b64);
-        break;
+        }				    
+	  
+	  /*
+	   * base64 encode the combined string and buld the HTTP auth header
+	   */
+	  est_base64_encode((const unsigned char *)both, strnlen(both, 2*MAX_UIDPWD), both_b64);
+	  snprintf(hdr + hdr_len, EST_HTTP_REQ_TOTAL_LEN-hdr_len,
+		   "Authorization: Basic %s\r\n", both_b64);
+	  break;
+    
     case AUTH_DIGEST:
 
         /* Generate a client nonce */
@@ -1111,6 +1124,14 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
             memset(pwd, 0, MAX_UIDPWD);
             
             est_client_retrieve_credentials(ctx, ctx->auth_mode, user, pwd);
+
+	    /*Check to make sure a valid userID and pwd was provided. If not point hdr to a null string*/
+	    if (user[0] == '\0' || pwd[0] == '\0'){
+     	      EST_LOG_ERR("No User ID or Password was provided, not trying another enrollment attempt.");
+	      /*Force hdr to a null string */
+	      memset(hdr, 0, EST_HTTP_REQ_TOTAL_LEN);	    
+	      break;
+	    }
         } else {
             if (!strncpy(user, ctx->userid, MAX_UIDPWD)) {
                 EST_LOG_ERR("Invalid User ID provided");
@@ -1119,8 +1140,10 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
                 EST_LOG_ERR("Invalid User password provided");
             }
         }
-        
-        digest = est_client_generate_auth_digest(ctx, uri, user, pwd);
+
+	
+
+	digest = est_client_generate_auth_digest(ctx, uri, user, pwd);
         if (digest == NULL) {
             EST_LOG_ERR("Error while generating digest");
             /* Force hdr to a null string */
@@ -1165,7 +1188,7 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
          */
         if (auth_credentials.auth_token == NULL) {
             EST_LOG_ERR("Requested token credentials, but application did not provide any.");
-            token = ""; 
+            token = ""; //error check here -- MD
         } else {
 
             /*
@@ -1181,7 +1204,16 @@ static void est_client_add_auth_hdr (EST_CTX *ctx, char *hdr, char *uri)
                 token = auth_credentials.auth_token;
             }
         }
-        
+
+	/*If the token is not valid, point hdr to a null string*/
+	if(strncmp(token, "", MAX_AUTH_TOKEN_LEN) == 0){
+	  /* Force hdr to a null string */	  
+	  EST_LOG_ERR("No valid token was provided, not trying another enrollment attempt.");
+	  memset(hdr, 0, EST_HTTP_REQ_TOTAL_LEN);
+	  break;
+	}
+
+	
         snprintf(hdr + hdr_len, EST_HTTP_REQ_TOTAL_LEN-hdr_len,
                  "Authorization: Bearer %s\r\n", token);
 
@@ -2698,7 +2730,7 @@ EST_ERROR est_client_enroll_csr (EST_CTX *ctx, X509_REQ *csr, int *pkcs7_len, EV
 	/*
 	 * Do a sanity check on the CSR
 	*/
-	rv = est_client_check_csr(csr); 
+      rv = est_client_check_csr(csr); 
 	if (EST_ERR_NONE != rv) {
 	    return (rv);
 	}

--- a/test/UT/US899/us899.c
+++ b/test/UT/US899/us899.c
@@ -1312,10 +1312,8 @@ static void us899_test18 (void)
  *
  * This is a basic test to perform a /simpleenroll without a 
  * user ID and password. 
- * No identity certificate is used by the client.
- * This test case uses the alternate enroll method where the CSR
- * is provided by the application layer rather than having libest
- * generate the CSR.
+ * The server will ask for Basic authentication, but the application will not provide
+ * a userID or password so the client will not retry an enrollment attempt. 
  */
 
 static void us899_test19 (void)
@@ -1391,10 +1389,9 @@ static void us899_test19 (void)
  *
  * This is a basic test to perform a /simpleenroll without a 
  * user ID and password. 
- * No identity certificate is used by the client.
- * This test case uses the alternate enroll method where the CSR
- * is provided by the application layer rather than having libest
- * generate the CSR.
+ * The server will ask for Digest authentication, but the application will not provide
+ * a userID or password so the client will not retry an enrollment attempt. 
+ *
  */
 
 static void us899_test20 (void)
@@ -1471,10 +1468,9 @@ static void us899_test20 (void)
  *
  * This is a basic test to perform a /simpleenroll without a 
  * user ID and password. 
- * No identity certificate is used by the client.
- * This test case uses the alternate enroll method where the CSR
- * is provided by the application layer rather than having libest
- * generate the CSR.
+ * This is a basic test to perform a /simpleenroll without a user ID and password. 
+ * The server will ask for Token authentication, but the application will not provide
+ * a userID or password so the client will not retry an enrollment attempt. 
  */
 
 static void us899_test21 (void)
@@ -1612,9 +1608,9 @@ int us899_add_suite (void)
        (NULL == CU_add_test(pSuite, "Simple enroll - CRL enabled, valid server cert", us899_test16)) ||
        (NULL == CU_add_test(pSuite, "Simple enroll - CRL enabled, revoked server cert", us899_test17)) ||
        (NULL == CU_add_test(pSuite, "Simple enroll - Retry-After received", us899_test18)) ||
-       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Basic Auth: No uID/pwd", us899_test19)) ||
-       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Digest Auth: No uID/pwd", us899_test20)) ||
-       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Token Auth: No uID/pwd", us899_test21)))
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Basic Auth - No uID/pwd", us899_test19)) ||
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Digest Auth - No uID/pwd", us899_test20)) ||
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Token Auth - No uID/pwd", us899_test21)))
    {
       CU_cleanup_registry();
       return CU_get_error();

--- a/test/UT/US899/us899.c
+++ b/test/UT/US899/us899.c
@@ -1307,6 +1307,249 @@ static void us899_test18 (void)
     est_destroy(ectx);
 }
 
+/*
+ * Simple enroll CSR -- No UserID or Password   
+ *
+ * This is a basic test to perform a /simpleenroll without a 
+ * user ID and password. 
+ * No identity certificate is used by the client.
+ * This test case uses the alternate enroll method where the CSR
+ * is provided by the application layer rather than having libest
+ * generate the CSR.
+ */
+
+static void us899_test19 (void)
+{
+    EST_CTX *ectx;
+    EVP_PKEY *key;
+    int rv;
+    int pkcs7_len = 0;
+    unsigned char *new_cert = NULL;
+    X509_REQ *csr;
+    unsigned char *attr_data = NULL;
+    int attr_len;
+
+    LOG_FUNC_NM;
+
+    /*
+     * Create a client context
+     */
+    ectx = est_client_init(cacerts, cacerts_len,
+                           EST_CERT_FORMAT_PEM,
+                           client_manual_cert_verify);
+    CU_ASSERT(ectx != NULL);
+
+    /*
+     * Set the authentication mode to use a user id/password
+     */
+    /*rv = est_client_set_auth(ectx, "", "" , NULL, NULL);
+      CU_ASSERT(rv == EST_ERR_NONE);*/ //Remove these
+
+    /*
+     * Set the EST server address/port
+     */
+    est_client_set_server(ectx, US899_SERVER_IP, US899_SERVER_PORT);
+
+    /*
+     * generate a private key
+     */
+    key = generate_private_key();
+    CU_ASSERT(key != NULL);
+
+    /*
+     * Generate a CSR
+     */
+    csr = X509_REQ_new();
+    CU_ASSERT(csr != NULL);
+    rv = populate_x509_csr(csr, key, "US899-TC2");
+
+    /*
+     * Get the latest CSR attributes
+     */
+    rv = est_client_get_csrattrs(ectx, &attr_data, &attr_len);
+    CU_ASSERT(rv == EST_ERR_NONE);
+
+    /*
+     * Use the alternate API to enroll an existing CSR
+     */
+    rv = est_client_enroll_csr(ectx, csr, &pkcs7_len, key);
+    CU_ASSERT(rv == EST_ERR_HTTP_CANNOT_BUILD_HEADER);
+ 
+    /*
+     * Cleanup
+     */
+    X509_REQ_free(csr);
+    EVP_PKEY_free(key);
+    if (new_cert) {
+        free(new_cert);
+    }
+    est_destroy(ectx);
+}
+
+/*
+ * Simple enroll CSR -- HTTP Digest Auth No UserID or Password   
+ *
+ * This is a basic test to perform a /simpleenroll without a 
+ * user ID and password. 
+ * No identity certificate is used by the client.
+ * This test case uses the alternate enroll method where the CSR
+ * is provided by the application layer rather than having libest
+ * generate the CSR.
+ */
+
+static void us899_test20 (void)
+{
+    EST_CTX *ectx;
+    EVP_PKEY *key;
+    int rv;
+    int pkcs7_len = 0;
+    unsigned char *new_cert = NULL;
+    X509_REQ *csr;
+    unsigned char *attr_data = NULL;
+    int attr_len;
+
+    LOG_FUNC_NM;
+
+    /*
+     * Create a client context
+     */
+    ectx = est_client_init(cacerts, cacerts_len,
+                           EST_CERT_FORMAT_PEM,
+                           client_manual_cert_verify);
+    CU_ASSERT(ectx != NULL);
+
+    /*
+     * Set the EST server address/port
+     */
+    est_client_set_server(ectx, US899_SERVER_IP, US899_SERVER_PORT);
+
+    /*
+     * generate a private key
+     */
+    key = generate_private_key();
+    CU_ASSERT(key != NULL);
+
+    /*
+     * Generate a CSR
+     */
+    csr = X509_REQ_new();
+    CU_ASSERT(csr != NULL);
+    rv = populate_x509_csr(csr, key, "US899-TC2");
+
+    /*
+     * Get the latest CSR attributes
+     */
+    rv = est_client_get_csrattrs(ectx, &attr_data, &attr_len);
+    CU_ASSERT(rv == EST_ERR_NONE);
+
+    /*
+     * Set the server authentication mode to Digest
+     */
+
+    st_enable_http_digest_auth();
+    
+    /*
+     * Use the alternate API to enroll an existing CSR
+     */
+    rv = est_client_enroll_csr(ectx, csr, &pkcs7_len, key);
+    CU_ASSERT(rv == EST_ERR_HTTP_CANNOT_BUILD_HEADER);
+ 
+    /*
+     * Cleanup
+     */
+    st_enable_http_basic_auth();
+    X509_REQ_free(csr);
+    EVP_PKEY_free(key);
+    if (new_cert) {
+        free(new_cert);
+    }
+    est_destroy(ectx);
+}
+
+/*
+ * Simple enroll CSR -- HTTP Token Auth No UserID or Password   
+ *
+ * This is a basic test to perform a /simpleenroll without a 
+ * user ID and password. 
+ * No identity certificate is used by the client.
+ * This test case uses the alternate enroll method where the CSR
+ * is provided by the application layer rather than having libest
+ * generate the CSR.
+ */
+
+static void us899_test21 (void)
+{
+    EST_CTX *ectx;
+    EVP_PKEY *key;
+    int rv;
+    int pkcs7_len = 0;
+    unsigned char *new_cert = NULL;
+    X509_REQ *csr;
+    unsigned char *attr_data = NULL;
+    int attr_len;
+
+    LOG_FUNC_NM;
+
+    /*
+     * Create a client context
+     */
+    ectx = est_client_init(cacerts, cacerts_len,
+                           EST_CERT_FORMAT_PEM,
+                           client_manual_cert_verify);
+    CU_ASSERT(ectx != NULL);
+
+    /*
+     * Set the EST server address/port
+     */
+    est_client_set_server(ectx, US899_SERVER_IP, US899_SERVER_PORT);
+
+    /*
+     * generate a private key
+     */
+    key = generate_private_key();
+    CU_ASSERT(key != NULL);
+
+    /*
+     * Generate a CSR
+     */
+    csr = X509_REQ_new();
+    CU_ASSERT(csr != NULL);
+    rv = populate_x509_csr(csr, key, "US899-TC2");
+
+    /*
+     * Get the latest CSR attributes
+     */
+    rv = est_client_get_csrattrs(ectx, &attr_data, &attr_len);
+    CU_ASSERT(rv == EST_ERR_NONE);
+
+    /*
+     * Set the server authentication mode to Digest
+     */
+
+    st_enable_http_token_auth();
+    
+    /*
+     * Use the alternate API to enroll an existing CSR
+     */
+    rv = est_client_enroll_csr(ectx, csr, &pkcs7_len, key);
+    CU_ASSERT(rv == EST_ERR_HTTP_CANNOT_BUILD_HEADER);
+ 
+    /*
+     * Cleanup
+     */
+    st_enable_http_basic_auth();
+    X509_REQ_free(csr);
+    EVP_PKEY_free(key);
+    if (new_cert) {
+        free(new_cert);
+    }
+    est_destroy(ectx);
+}
+
+
+
+
+
 //TO DO
 //
 //Auth (HTTP basic auth enabled on server) 
@@ -1368,7 +1611,10 @@ int us899_add_suite (void)
        (NULL == CU_add_test(pSuite, "Simple enroll - wildcard mismatch FQDN SAN", us899_test15)) ||
        (NULL == CU_add_test(pSuite, "Simple enroll - CRL enabled, valid server cert", us899_test16)) ||
        (NULL == CU_add_test(pSuite, "Simple enroll - CRL enabled, revoked server cert", us899_test17)) ||
-       (NULL == CU_add_test(pSuite, "Simple enroll - Retry-After received", us899_test18)))
+       (NULL == CU_add_test(pSuite, "Simple enroll - Retry-After received", us899_test18)) ||
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Basic Auth: No uID/pwd", us899_test19)) ||
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Digest Auth: No uID/pwd", us899_test20)) ||
+       (NULL == CU_add_test(pSuite, "Simple enroll - HTTP Token Auth: No uID/pwd", us899_test21)))
    {
       CU_cleanup_registry();
       return CU_get_error();


### PR DESCRIPTION
Prevented the client from retrying an enrollment attempt when no http authentication uid/pwd is available, since it is not capable of Basic or Digest authentication anyway. This is required by RFC 7030 section 3.2.3 and also avoids overhead due to a needless round trip.

Changes were made to est_client.c and us899.c