### PR TITLE
Ddvo contrib5: improvements to est_client.c/verify_cacert_resp() and Makefiles

### DIFF
--- a/example/client-simple/Makefile.am
+++ b/example/client-simple/Makefile.am
@@ -1,10 +1,13 @@
 bin_PROGRAMS = estclient_simple
 estclient_simple_includedir=$(includedir)/est
 estclient_simple_SOURCES = estclient-simple.c ../util/utils.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
+
 if FREEBSD 
 DL=
 else
 DL=-ldl
 endif
-estclient_simple_LDFLAGS = -L../../src/est/.libs $(DL) -lest -lssl -lcrypto 
+
+estclient_simple_LDFLAGS = -L../../src/est/.libs -lest
+estclient_simple_DEPENDENCIES = ../../src/est/.libs/libest.*

--- a/example/client-simple/Makefile.in
+++ b/example/client-simple/Makefile.in
@@ -286,10 +286,11 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 estclient_simple_includedir = $(includedir)/est
 estclient_simple_SOURCES = estclient-simple.c ../util/utils.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
 @FREEBSD_FALSE@DL = -ldl
 @FREEBSD_TRUE@DL = 
-estclient_simple_LDFLAGS = -L../../src/est/.libs $(DL) -lest -lssl -lcrypto 
+estclient_simple_LDFLAGS = -L../../src/est/.libs -lest
+estclient_simple_DEPENDENCIES = ../../src/est/.libs/libest.*
 all: all-am
 
 .SUFFIXES:

--- a/example/client/Makefile.am
+++ b/example/client/Makefile.am
@@ -1,7 +1,8 @@
 bin_PROGRAMS = estclient
 estclient_includedir=$(includedir)/est
 estclient_SOURCES = estclient.c ../util/utils.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
+
 if FREEBSD 
 DL=
 else
@@ -13,4 +14,5 @@ PTHREAD=
 else
 PTHREAD=-lpthread
 endif
-estclient_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estclient_LDFLAGS = -L../../src/est/.libs -lest
+estclient_DEPENDENCIES = ../../src/est/.libs/libest.*

--- a/example/client/Makefile.in
+++ b/example/client/Makefile.in
@@ -284,12 +284,13 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 estclient_includedir = $(includedir)/est
 estclient_SOURCES = estclient.c ../util/utils.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
 @FREEBSD_FALSE@DL = -ldl
 @FREEBSD_TRUE@DL = 
 @DISABLE_PTHREAD_FALSE@PTHREAD = -lpthread
 @DISABLE_PTHREAD_TRUE@PTHREAD = 
-estclient_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estclient_LDFLAGS = -L../../src/est/.libs -lest
+estclient_DEPENDENCIES = ../../src/est/.libs/libest.*
 all: all-am
 
 .SUFFIXES:

--- a/example/proxy/Makefile.am
+++ b/example/proxy/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = estproxy
 estproxy_SOURCES = estproxy.c ../util/utils.c ../util/simple_server.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
 if FREEBSD 
 DL=
 else
@@ -13,6 +13,7 @@ else
 PTHREAD=-lpthread
 endif
 
-estproxy_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estproxy_LDFLAGS = -L../../src/est/.libs -lest
+estproxy_DEPENDENCIES = ../../src/est/.libs/libest.*
 
 EXTRA_DIST = createRA.sh runproxy.sh estExampleCA.cnf

--- a/example/proxy/Makefile.in
+++ b/example/proxy/Makefile.in
@@ -284,12 +284,13 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 estproxy_SOURCES = estproxy.c ../util/utils.c ../util/simple_server.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
 @FREEBSD_FALSE@DL = -ldl
 @FREEBSD_TRUE@DL = 
 @DISABLE_PTHREAD_FALSE@PTHREAD = -lpthread
 @DISABLE_PTHREAD_TRUE@PTHREAD = 
-estproxy_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estproxy_LDFLAGS = -L../../src/est/.libs -lest
+estproxy_DEPENDENCIES = ../../src/est/.libs/libest.*
 EXTRA_DIST = createRA.sh runproxy.sh estExampleCA.cnf
 all: all-am
 

--- a/example/server/Makefile.am
+++ b/example/server/Makefile.am
@@ -1,7 +1,8 @@
 bin_PROGRAMS = estserver
 estclient_includedir=$(includedir)/est
 estserver_SOURCES = estserver.c ossl_srv.c ../util/utils.c ../util/simple_server.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
+
 if FREEBSD 
 DL=
 else
@@ -14,6 +15,7 @@ else
 PTHREAD=-lpthread
 endif
 
-estserver_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estserver_LDFLAGS = -L../../src/est/.libs -lest
+estserver_DEPENDENCIES = ../../src/est/.libs/libest.*
 
 EXTRA_DIST = ossl_srv.h apps.h createCA.sh ext.cnf ESTcommon.sh runserver.sh estExampleCA.cnf extExampleCA.cnf

--- a/example/server/Makefile.in
+++ b/example/server/Makefile.in
@@ -285,12 +285,13 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 estclient_includedir = $(includedir)/est
 estserver_SOURCES = estserver.c ossl_srv.c ../util/utils.c ../util/simple_server.c 
-AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est -I$(SSL_CFLAGS) -g
+AM_CFLAGS = -I../.. -I$(srcdir)/../../src/est
 @FREEBSD_FALSE@DL = -ldl
 @FREEBSD_TRUE@DL = 
 @DISABLE_PTHREAD_FALSE@PTHREAD = -lpthread
 @DISABLE_PTHREAD_TRUE@PTHREAD = 
-estserver_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto 
+estserver_LDFLAGS = -L../../src/est/.libs -lest
+estserver_DEPENDENCIES = ../../src/est/.libs/libest.*
 EXTRA_DIST = ossl_srv.h apps.h createCA.sh ext.cnf ESTcommon.sh runserver.sh estExampleCA.cnf extExampleCA.cnf
 all: all-am
 

--- a/test/UT/Makefile
+++ b/test/UT/Makefile
@@ -44,7 +44,7 @@ CCFLAGS = -Wall -g -DHAVE_CUNIT -DNO_SSL_DL
 CC = gcc
 
 # linker flags
-LDFLAGS += -lcunit -ldl -lpthread -lssl -lcrypto -lest -lcurl
+LDFLAGS += -lcunit -ldl -lpthread -lest -lssl -lcrypto -lcurl
 
 # library paths
 LIBS = -L../../src/est/.libs -L$(OPENSSL_DIR)/lib -L$(CURL_DIR)/lib $(LDFLAGS) 
@@ -57,7 +57,7 @@ default:	runtest
 .c.o:
 	$(CC) $(INCLUDES) $(CCFLAGS) -c $< -o $@
 
-runtest: $(OBJ)
+runtest: $(OBJ) ../../src/est/.libs/libest.*
 	$(CC) -o $(OUT) $(OBJ) $(LIBS) 
 
 clean:


### PR DESCRIPTION
As requested, removed inefficiencies and memory leak from verify_cacert_resp()
I also simplified its deallocation code, curing wrong deallocation order
- as written in http://linux.die.net/man/3/x509_store_ctx_init
The certificates and CRLs in a context are used internally and should not be freed up until after the associated X509_STORE_CTX is freed.

While compiling the example estclient etc, I found again that their Makefiles do not have a reference to libest, such that they are not re-built by a local "make" when libest was updated. I added the missing references, also for the unit tests, and in the course of doing so, I removed some duplicate compiler and linker arguments.
