### PR TITLE
Create a Dockerfile for containerizing examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+
+RUN mkdir -p /src
+WORKDIR /src
+ADD . /src
+# This is ugly, however, keeping it in one command cuts the resultant image
+# size in half
+RUN apt update && apt install -y openssl libssl-dev build-essential && \
+    ./configure && \
+    make install && \
+    rm -rf /src && \
+    apt remove --quiet -y libssl-dev build-essential && \
+    apt autoremove -y && \
+    apt clean -y && \
+    apt autoclean -y && \
+    rm -rf /var/lib/apt /tmp/* /var/tmp/*

--- a/README
+++ b/README
@@ -99,6 +99,14 @@ Android NDK:
     make
     make install
 
+Docker
+------
 
+A Dockerfile is included to make running the examples easy. You can build the container with:
 
+    docker build -t libest:latest .
+
+Once built, the example binaries are installed in /usr/local/est/bin. Run them like so:
+
+    docker run libest:latest /usr/local/est/bin/estserver --help
 


### PR DESCRIPTION
This commit introduces a basic Dockerfile based on Ubuntu 16.04. The
built container contains the result of make install along with required
dependencies. The README was updated with usage instructions.