### PR TITLE
Fix NULL pointer dereference

### DIFF
--- a/example/util/utils.c
+++ b/example/util/utils.c
@@ -179,6 +179,9 @@ char *generate_private_EC_key (int curve_nid, pem_password_cb *cb)
     }
 
     group = EC_GROUP_new_by_curve_name(curve_nid);
+    if (!group) {
+        return NULL;
+    }
     EC_GROUP_set_asn1_flag(group, asn1_flag);
     EC_GROUP_set_point_conversion_form(group, form);
     EC_KEY_set_group(eckey, group);


### PR DESCRIPTION
Fix NULL pointer dereference.  Found by Coverity Connect.