### PR TITLE
Possible Buffer overflow: add length checks to header creation

### DIFF
--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -1274,6 +1274,11 @@ static int est_client_build_cacerts_header (EST_CTX *ctx, char *hdr)
         EST_LOG_WARN("CA Certs header took up the maximum amount in buffer (%d)",
                      EST_HTTP_REQ_TOTAL_LEN);
     }
+
+    if(hdr_len > EST_HTTP_HDR_MAX) {
+        EST_LOG_ERR("CA Certs header is too big (%d) > (%d)", hdr_len, EST_HTTP_HDR_MAX);
+        return 0;
+    }
     
     return (hdr_len);
 }
@@ -1307,6 +1312,12 @@ static int est_client_build_csr_header (EST_CTX *ctx, char *hdr)
         EST_LOG_WARN("CSR attributes request header took up the maximum amount in buffer (%d)",
                      EST_HTTP_REQ_TOTAL_LEN);
     }
+
+    if(hdr_len > EST_HTTP_HDR_MAX) {
+        EST_LOG_ERR("CSR attributes header is too big (%d) > (%d)", hdr_len, EST_HTTP_HDR_MAX);
+        return 0;
+    }
+
     return (hdr_len);
 }
 
@@ -1435,6 +1446,11 @@ static int est_client_build_enroll_header (EST_CTX *ctx, char *hdr, int pkcs10_l
         EST_LOG_WARN("Client enroll request header took up the maximum amount in buffer (%d)",
                      EST_HTTP_REQ_TOTAL_LEN);
     }
+
+    if(hdr_len > EST_HTTP_HDR_MAX) {
+        EST_LOG_ERR("Client enroll request header is too big (%d) > (%d)", hdr_len, EST_HTTP_HDR_MAX);
+        return 0;
+    }
     
     return (hdr_len);
 }
@@ -1471,6 +1487,12 @@ static int est_client_build_reenroll_header (EST_CTX *ctx, char *hdr, int pkcs10
         EST_LOG_WARN("Client reenroll request header took up the maximum amount in buffer (%d)",
                      EST_HTTP_REQ_TOTAL_LEN);
     }
+
+    if(hdr_len > EST_HTTP_HDR_MAX) {
+        EST_LOG_ERR("Client reenroll request header is too big (%d) > (%d)", hdr_len, EST_HTTP_HDR_MAX);
+        return 0;
+    }
+
     return (hdr_len);
 }
 
@@ -2615,6 +2637,12 @@ static int est_client_send_cacerts_request (EST_CTX *ctx, SSL *ssl,
     }
     
     hdr_len = est_client_build_cacerts_header(ctx, http_data);
+    if(hdr_len == 0) {
+        EST_LOG_ERR("Unable to build CA Cert header");
+        free(http_data);
+        return (EST_ERR_HTTP_CANNOT_BUILD_HEADER);
+    }
+
     /*
      * terminate the HTTP header
      */

--- a/src/est/est_server.c
+++ b/src/est/est_server.c
@@ -111,13 +111,13 @@ int est_handle_cacerts (EST_CTX *ctx, unsigned char *ca_certs, int ca_certs_len,
     snprintf(http_hdr, EST_HTTP_HDR_MAX, "%s%s%s%s", EST_HTTP_HDR_200, EST_HTTP_HDR_EOL,
              EST_HTTP_HDR_STAT_200, EST_HTTP_HDR_EOL);
     hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %s%s", EST_HTTP_HDR_CT,
+    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %s%s", EST_HTTP_HDR_CT,
              EST_HTTP_CT_PKCS7, EST_HTTP_HDR_EOL);
     hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %s%s", EST_HTTP_HDR_CE,
+    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %s%s", EST_HTTP_HDR_CE,
              EST_HTTP_CE_BASE64, EST_HTTP_HDR_EOL);
     hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %d%s%s", EST_HTTP_HDR_CL,
+    snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %d%s%s", EST_HTTP_HDR_CL,
              ca_certs_len, EST_HTTP_HDR_EOL, EST_HTTP_HDR_EOL);
     if (!mg_write(http_ctx, http_hdr, strnlen_s(http_hdr, EST_HTTP_HDR_MAX))) {
         return (EST_ERR_HTTP_WRITE);
@@ -1193,13 +1193,13 @@ static EST_ERROR est_handle_simple_enroll (EST_CTX *ctx, void *http_ctx, SSL *ss
         snprintf(http_hdr, EST_HTTP_HDR_MAX, "%s%s%s%s", EST_HTTP_HDR_200, EST_HTTP_HDR_EOL,
                  EST_HTTP_HDR_STAT_200, EST_HTTP_HDR_EOL);
         hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %s%s", EST_HTTP_HDR_CT,
+        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %s%s", EST_HTTP_HDR_CT,
                  EST_HTTP_CT_PKCS7_CO, EST_HTTP_HDR_EOL);
         hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %s%s", EST_HTTP_HDR_CE,
+        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %s%s", EST_HTTP_HDR_CE,
                  EST_HTTP_CE_BASE64, EST_HTTP_HDR_EOL);
         hdrlen = strnlen_s(http_hdr, EST_HTTP_HDR_MAX);
-        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX, "%s: %d%s%s", EST_HTTP_HDR_CL,
+        snprintf(http_hdr + hdrlen, EST_HTTP_HDR_MAX - hdrlen, "%s: %d%s%s", EST_HTTP_HDR_CL,
                  cert_len, EST_HTTP_HDR_EOL, EST_HTTP_HDR_EOL);
         if (!mg_write(http_ctx, http_hdr, strnlen_s(http_hdr, EST_HTTP_HDR_MAX))) {
             free(cert);


### PR DESCRIPTION
### est_client.c:
When the generated header is bigger than EST_HTTP_HDR_MAX the
```C
/*
 * Build the HTTP body containing the pkcs10 request
 */
memcpy_s(http_data + hdr_len, EST_HTTP_REQ_DATA_MAX,
         bptr->data, (rsize_t)bptr->length);
hdr_len += bptr->length;
```
will result in a memory corruption, because of http_data + hdr_len

### est_server.c
snprintf() should check how much space is left in the header