### PR TITLE
fix memory leak in /cacert operation on clientside

### DIFF
--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -631,6 +631,7 @@ static EST_ERROR verify_cacert_resp (EST_CTX *ctx, unsigned char *cacerts,
             EST_LOG_WARN("Certificate failed verification (%s)", current_cert->name);
             failed = 1;
         }
+        X509_STORE_CTX_cleanup(store_ctx);
     }
 
     /*


### PR DESCRIPTION
there is a memory leak on the clientside

#### openssl manpage  (https://www.openssl.org/docs/man1.0.2/crypto/X509_STORE_CTX_init.html):
X509_STORE_CTX_cleanup() internally cleans up an X509_STORE_CTX structure. The context can then be reused with an new call to X509_STORE_CTX_init().