### PR TITLE
Fixes to build and test on FreeBSD with clang.

### DIFF
--- a/src/est/est_client_proxy.c
+++ b/src/est/est_client_proxy.c
@@ -25,6 +25,7 @@
 #   include <netdb.h>
 #   include <unistd.h>
 #   include <arpa/inet.h>
+#   include <netinet/in.h>
 #endif /* WIN32 */
 #include <errno.h>
 #include <string.h>

--- a/src/est/est_client_proxy.c
+++ b/src/est/est_client_proxy.c
@@ -25,8 +25,10 @@
 #   include <netdb.h>
 #   include <unistd.h>
 #   include <arpa/inet.h>
-#   include <netinet/in.h>
 #endif /* WIN32 */
+#ifdef __FreeBSD__
+#   include <netinet/in.h>
+#endif /* __FreeBSD__ */
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>

--- a/test/README
+++ b/test/README
@@ -12,6 +12,15 @@ To use the unit test, descend into the the UT directory and issue
 the 'make' command.  If your host meets the dependencies, the target
 'runtest' should be built.  Running this from the command line
 should run all the unit tests.  The OpenSSL libraries and libest
-should be in your shared library path (LD_LIBRARY_PATH) prior to 
+should be in your shared library path (LD_LIBRARY_PATH) prior to
 running the unit tests.
 
+Some tests require that 'localhost.cisco.com' be resolvable.  You
+can accommodate this by placing this line in your system's hosts
+file:
+
+127.0.0.1       localhost.cisco.com
+
+This file is located in /etc/hosts on *nix-like systems, in
+C:\Windows\System32\Drivers\etc\hosts on Windows, and in
+/private/etc/hosts on Mac OS X 10.6 to 10.12.

--- a/test/UT/Makefile
+++ b/test/UT/Makefile
@@ -87,7 +87,6 @@ LIBS = -L../../src/est/.libs -L$(URIPARSER_DIR)/lib -L$(OPENSSL_DIR)/lib -L$(CUR
 default:	runtest
 
 .c.o:
-	echo $(CC_VERS)
 	$(CC) $(INCLUDES) $(CCFLAGS) -c $< -o $@
 
 runtest: $(OBJ)

--- a/test/UT/Makefile
+++ b/test/UT/Makefile
@@ -60,10 +60,21 @@ INCLUDES = -I../../src/est -I../.. -I../util -I$(OPENSSL_DIR)/include -I$(CURL_D
 CCFLAGS = -Wall -g -DHAVE_CUNIT -DNO_SSL_DL $(CURL_CC_DEFINE)
 
 # compiler
+CC_VERS = $(shell cc --version | grep -o 'clang\|gcc' )
+ifeq "$(CC_VERS)" "clang"
+CC = cc
+else
 CC = gcc
+endif
 
 # linker flags
-LDFLAGS += -lcunit -ldl -lpthread -lssl -lcrypto -lest -lcurl $(URIPARSER_LDFLAGS)
+OS = $(shell uname -s)
+ifeq "$(OS)" "FreeBSD"
+DL =
+else
+DL = -ldl
+endif
+LDFLAGS += -lcunit $(DL) -lpthread -lssl -lcrypto -lest -lcurl $(URIPARSER_LDFLAGS)
 
 # library paths
 LIBS = -L../../src/est/.libs -L$(URIPARSER_DIR)/lib -L$(OPENSSL_DIR)/lib -L$(CURL_DIR)/lib -L$(CUNIT_DIR)/lib $(LDFLAGS)
@@ -76,6 +87,7 @@ LIBS = -L../../src/est/.libs -L$(URIPARSER_DIR)/lib -L$(OPENSSL_DIR)/lib -L$(CUR
 default:	runtest
 
 .c.o:
+	echo $(CC_VERS)
 	$(CC) $(INCLUDES) $(CCFLAGS) -c $< -o $@
 
 runtest: $(OBJ)

--- a/test/util/st_server.c
+++ b/test/util/st_server.c
@@ -719,7 +719,7 @@ static void cleanup()
      * manual cert approval
      */
     if (lookup_root) {
-       /* tdestroy() if a GNU C extension.
+       /* tdestroy() is a GNU C extension.
         * If we are not using GNU C, skip it and let memory leak. */
 #if defined(__GNUC__) && !defined(__clang__)
         tdestroy((void *)lookup_root, free_lookup);

--- a/test/util/st_server.c
+++ b/test/util/st_server.c
@@ -719,7 +719,13 @@ static void cleanup()
      * manual cert approval
      */
     if (lookup_root) {
+       /* tdestroy() if a GNU C extension.
+        * If we are not using GNU C, skip it and let memory leak. */
+#if defined(__GNUC__) && !defined(__clang__)
         tdestroy((void *)lookup_root, free_lookup);
+#else
+        free( lookup_root );
+#endif
 	lookup_root = NULL;
     }
 


### PR DESCRIPTION
These are the changes I needed to make to build the library, and run the unit tests successfully, on FreeBSD 11.0 using clang 3.8.0.