### PR TITLE
remove SSL_OP_NO_TICKET

### DIFF
--- a/src/est/est_server_http.c
+++ b/src/est/est_server_http.c
@@ -1462,8 +1462,7 @@ static int set_ssl_option (struct mg_context *ctx)
     SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 |
                         SSL_OP_NO_SSLv3 |
                         SSL_OP_NO_TLSv1 |
-                        SSL_OP_SINGLE_ECDH_USE |
-                        SSL_OP_NO_TICKET);
+                        SSL_OP_SINGLE_ECDH_USE);
 
 
     /* 


### PR DESCRIPTION
disabling the tls session resumption causes with the command SSL_shutdown() high memory consumption, when a client authenticates with TLS mutual on /cacerts or/and /csrattrs

fixes #56