### PR TITLE
Changes to autotools files to enable VPATH builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,15 +128,17 @@ AC_ARG_WITH([uriparser-dir],
         ]
        )
 
-SAFEC_STUB_DIR='$(abs_top_builddir)/safe_c_stub'
-AC_SUBST(SAFEC_STUB_DIR)
-safecdir="$SAFEC_STUB_DIR" 
-AC_SUBST([SAFEC_DIR], "$safecdir")
-AC_SUBST([SAFEC_CFLAGS], "$safecdir/include")
-AC_SUBST([SAFEC_LDFLAGS], "$safecdir/lib")
+SAFEC_STUB_SRCDIR='$(abs_top_srcdir)/safe_c_stub'
+SAFEC_STUB_BLDDIR='$(abs_top_builddir)/safe_c_stub'
+AC_SUBST(SAFEC_STUB_SRCDIR)
+safecsrcdir="$SAFEC_STUB_SRCDIR"
+safecblddir="$SAFEC_STUB_BLDDIR" 
+AC_SUBST([SAFEC_DIR], "$safecsrcdir")
+AC_SUBST([SAFEC_CFLAGS], "$safecsrcdir/include")
+AC_SUBST([SAFEC_LDFLAGS], "$safecblddir/lib")
 
-CFLAGS="$CFLAGS -Wall -I$safecdir/include"
-LDFLAGS="$LDFLAGS -L$safecdir/lib"
+CFLAGS="$CFLAGS -Wall -I$safecsrcdir/include"
+LDFLAGS="$LDFLAGS -L$safecblddir/lib"
 LIBS="$LIBS -lsafe_lib"
 
 AC_PREFIX_DEFAULT([/usr/local/est])

--- a/example/client-simple/Makefile.am
+++ b/example/client-simple/Makefile.am
@@ -7,4 +7,4 @@ DL=
 else
 DL=-ldl
 endif
-estclient_simple_LDFLAGS = -L../../src/est/.libs $(DL) -lest -lssl -lcrypto
+estclient_simple_LDFLAGS = -L$(abs_top_builddir)/src/est/.libs $(DL) -lest -lssl -lcrypto

--- a/example/client/Makefile.am
+++ b/example/client/Makefile.am
@@ -14,4 +14,4 @@ else
 PTHREAD=-lpthread
 endif
 
-estclient_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto
+estclient_LDFLAGS = -L$(abs_top_builddir)/src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto

--- a/example/proxy/Makefile.am
+++ b/example/proxy/Makefile.am
@@ -13,6 +13,6 @@ else
 PTHREAD=-lpthread
 endif
 
-estproxy_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto
+estproxy_LDFLAGS = -L$(abs_top_builddir)/src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto
 
 EXTRA_DIST = createRA.sh runproxy.sh estExampleCA.cnf

--- a/example/server/Makefile.am
+++ b/example/server/Makefile.am
@@ -14,6 +14,6 @@ else
 PTHREAD=-lpthread
 endif
 
-estserver_LDFLAGS = -L../../src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto
+estserver_LDFLAGS = -L$(abs_top_builddir)/src/est/.libs $(DL) $(PTHREAD) -lest -lssl -lcrypto
 
 EXTRA_DIST = ossl_srv.h apps.h createCA.sh ext.cnf ESTcommon.sh runserver.sh estExampleCA.cnf extExampleCA.cnf


### PR DESCRIPTION
These changes allow the configure script to be called from an
arbitrary build directory separate from the source. The source
directory contains the source and the configure script. The Makefile,
object files, libraries, and executables are all generated in the
build directory. This is useful when using the same source directory
to build for multiple target environments (x86 vs ARM) or multiple
configurations (debug vs release).

configure.ac: statements-related to safec are modified to distinguish
between the source tree and build tree. "-I" flags should reference
the source tree (containing the headers). "-L" flags should reference
the build tree (containing the libraries). Similar changes made to
"Makefile.am" files.

Signed-off-by: Safayet N Ahmed <Safayte.Ahmed@ge.com>