### PR TITLE
OpenSSL-1-1-1 support

### DIFF
--- a/example/proxy/estproxy.c
+++ b/example/proxy/estproxy.c
@@ -269,8 +269,11 @@ static int process_ssl_srp_auth (SSL *s, int *ad, void *arg)
 
     if (!login)
         return (-1);
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     user = SRP_VBASE_get_by_user(srp_db, login);
+#else
+    user = SRP_VBASE_get1_by_user(srp_db, login);
+#endif
 
     if (user == NULL) {
         printf("User doesn't exist in SRP database\n");
@@ -494,7 +497,11 @@ int main (int argc, char **argv)
     /*
      * Read in the local server certificate 
      */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     certin = BIO_new(BIO_s_file_internal());
+#else
+    certin = BIO_new(BIO_s_file());
+#endif
     if (BIO_read_filename(certin, certfile) <= 0) {
         printf("\nUnable to read server certificate file %s\n", certfile);
         exit(1);
@@ -514,7 +521,11 @@ int main (int argc, char **argv)
     /* 
      * Read in the server's private key
      */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     keyin = BIO_new(BIO_s_file_internal());
+#else
+    keyin = BIO_new(BIO_s_file());
+#endif
     if (BIO_read_filename(keyin, keyfile) <= 0) {
         printf("\nUnable to read server private key file %s\n", keyfile);
         exit(1);

--- a/example/util/utils.c
+++ b/example/util/utils.c
@@ -266,7 +266,11 @@ EVP_PKEY *read_private_key(const char *key_file, pem_password_cb *cb)
     /*
      * Read in the private key
      */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     keyin = BIO_new(BIO_s_file_internal());
+#else
+    keyin = BIO_new(BIO_s_file());
+#endif
     if (BIO_read_filename(keyin, key_file) <= 0) {
     EST_LOG_ERR("Unable to read private key file %s", key_file);
     return(NULL);

--- a/src/est/est.c
+++ b/src/est/est.c
@@ -1128,7 +1128,11 @@ EST_ERROR est_asn1_sanity_test (const unsigned char *string, long out_len,
 	switch (tag)
 	{
 	case V_ASN1_OBJECT:
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             a_object = c2i_ASN1_OBJECT(NULL, &string, len);
+#else
+            a_object = d2i_ASN1_OBJECT(NULL, &string, len);
+#endif
 	    if (a_object != NULL) {
 	        nid = OBJ_obj2nid(a_object);
 		EST_LOG_INFO("NID=%d", nid);
@@ -1485,7 +1489,11 @@ EST_ERROR est_get_attributes_helper (unsigned char **der_ptr, int *der_len, int 
 	switch (tag) {
 
 	case V_ASN1_OBJECT:
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             a_object = c2i_ASN1_OBJECT(NULL, &string, len);
+#else
+            a_object = d2i_ASN1_OBJECT(NULL, &string, len);
+#endif
 	    if (a_object != NULL) {
 	        nid = OBJ_obj2nid(a_object);
 		EST_LOG_INFO("NID=%d", nid);

--- a/src/est/est.h
+++ b/src/est/est.h
@@ -511,12 +511,21 @@ LIBEST_API int est_convert_p7b64_to_pem(unsigned char *certs_p7, int certs_len, 
  
     @return void.
  */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define est_apps_startup() \
     do { CRYPTO_malloc_init(); \
          ERR_load_crypto_strings(); OpenSSL_add_all_algorithms(); \
          ENGINE_load_builtin_engines(); \
          SSL_library_init(); \
          SSL_load_error_strings(); } while (0)
+#else
+#define est_apps_startup() \
+	    do { OPENSSL_malloc_init(); \
+		             ERR_load_crypto_strings(); OpenSSL_add_all_algorithms(); \
+		             ENGINE_load_builtin_engines(); \
+		             SSL_library_init(); \
+		             SSL_load_error_strings(); } while (0)
+#endif
 
 /*! @brief est_apps_shutdown() is used by an application to de-initialize 
     the OpenSSL library.  This should be called to prevent memory
@@ -524,15 +533,22 @@ LIBEST_API int est_convert_p7b64_to_pem(unsigned char *certs_p7, int certs_len, 
     CONF_modules_unload(), OBJ_cleanup(), EVP_cleanup(), ENGINE_cleanup(),
     CRYPTO_cleanup_all_ex_data(), ERR_remove_thread_state(), and
     ERR_free_strings().
- 
+    ERR_remove_thread_state is deprecated in versions greater than 0x10100000L
     @return void.
  */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define est_apps_shutdown() \
     do { CONF_modules_unload(1); \
          OBJ_cleanup(); EVP_cleanup(); ENGINE_cleanup(); \
          CRYPTO_cleanup_all_ex_data(); ERR_remove_thread_state(NULL); \
          ERR_free_strings(); } while (0)
-
+#else
+#define est_apps_shutdown() \
+    do { CONF_modules_unload(1); \
+         OBJ_cleanup(); EVP_cleanup(); ENGINE_cleanup(); \
+         CRYPTO_cleanup_all_ex_data();  \
+         ERR_free_strings(); } while (0)
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/est/est_locl.h
+++ b/src/est/est_locl.h
@@ -43,7 +43,13 @@
 #define EST_URI_MAX_LEN     (EST_URI_PATH_PREFIX_MAX_LEN+EST_MAX_PATH_SEGMENT_LEN+EST_MAX_PATH_SEGMENT_LEN)
 #define EST_BODY_MAX_LEN    16384
 #define EST_CA_MAX	    2000000
+/*Value which comes after the read in BIO_get_mem_ptr is 
+64 in openssl 1.1.1 as compared to 16 in older versions*/
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define EST_TLS_UID_LEN     17
+#else
+#define EST_TLS_UID_LEN     65
+#endif
 #define EST_RAW_CSR_LEN_MAX 8192
 
 #define EST_MAX_CONTENT_LEN 8192

--- a/src/est/est_ossl_util.c
+++ b/src/est/est_ossl_util.c
@@ -179,7 +179,13 @@ static int ossl_init_cert_store_from_raw (X509_STORE *store,
     while (sk_X509_INFO_num(sk)) {
         xi = sk_X509_INFO_shift(sk);
         if (xi->x509 != NULL) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             EST_LOG_INFO("Adding cert to store (%s)", xi->x509->name);
+#else
+           char *issuer = X509_NAME_oneline(X509_get_issuer_name(xi->x509), NULL, 0);
+           EST_LOG_INFO("Adding cert to store (%s)",issuer);
+
+#endif
             X509_STORE_add_cert(store, xi->x509);
 	    cert_cnt++;
         }

--- a/src/est/est_server.c
+++ b/src/est/est_server.c
@@ -531,9 +531,11 @@ int est_tls_uid_auth (EST_CTX *ctx, SSL *ssl, X509_REQ *req)
     X509_ATTRIBUTE *attr;
     int i, j;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ASN1_TYPE *at;
-    ASN1_BIT_STRING *bs = NULL;
     ASN1_TYPE *t;
+#endif
+    ASN1_BIT_STRING *bs = NULL;
     int rv = EST_ERR_NONE;
     char *tls_uid;
     int diff;
@@ -566,6 +568,7 @@ int est_tls_uid_auth (EST_CTX *ctx, SSL *ssl, X509_REQ *req)
          * If we found the attribute, get the actual value of the challengePassword
          */
         if (attr) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             if (attr->single) {
                 t = attr->value.single;
                 bs = t->value.bit_string;
@@ -573,7 +576,18 @@ int est_tls_uid_auth (EST_CTX *ctx, SSL *ssl, X509_REQ *req)
                 j = 0;
                 at = sk_ASN1_TYPE_value(attr->value.set, j);
                 bs = at->value.asn1_string;
+#else
+		ASN1_TYPE   *value;
+		value  = X509_ATTRIBUTE_get0_type(attr, 0);
+
+		if ((value != NULL) && (value->type == V_ASN1_BIT_STRING )) {
+			bs = value ->value.bit_string;
+		}
+
+		if ((value != NULL) && (value->type == V_ASN1_GENERALSTRING )) {
+			bs = value ->value.asn1_string;
             }
+#endif
         } else {
             EST_LOG_WARN("PoP challengePassword attribute not found in client cert request");
             return (EST_ERR_AUTH_FAIL_TLSUID);
@@ -970,7 +984,11 @@ static EST_ERROR est_server_all_csrattrs_present(EST_CTX *ctx, char *body, int b
         }
 	switch (tag) {
 	case V_ASN1_OBJECT:
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             a_object = c2i_ASN1_OBJECT(NULL, (const unsigned char**)&der_ptr, len);
+#else
+            a_object = d2i_ASN1_OBJECT(NULL, (const unsigned char**)&der_ptr, len);
+#endif
 	    if (!a_object) {
 		EST_LOG_ERR("a_object is null");
 	        est_server_free_csr_oid_list(csr_attr_oids);


### PR DESCRIPTION
This patch provides support for compiling libEST for OpenSSL-1.1.1
OpenSSL version is:

OpenSSL 1.1.1  11 Sep 2018


File: example/server/ossl_srv.c
1. Could not find equivalent in OpenSSL 1.1.1 for NETSCAPE_X509 ,so disabled the support .
2. Also at some places  i see the code "req->req_info->enc.modified = 1 " where we have set the modified bit,i could not find an equivalent. 
If anybody finds the workaround,please update.
3.Could not find the replacement for  c2i_ASN1_OBJECT ,so converted to d2i_ASN1_OBJECT.
Could not find any equivalent,so replaced this . Please see if its ok.

I have tested the example client/server on OpenSSL 1.1.1 and it works fine.