### PR TITLE
configure.ac: remove duplicate invocation of AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ AC_CONFIG_SRCDIR(example/server/estserver.c)
 AC_CONFIG_SRCDIR(example/proxy/estproxy.c)
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
 AM_INIT_AUTOMAKE([subdir-objects])
 


### PR DESCRIPTION
autoreconf fails with:

configure.ac:9: error: AM_INIT_AUTOMAKE expanded multiple times
/home/thomas/projets/buildroot/output/host/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:7: the top level
/home/thomas/projets/buildroot/output/host/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:9: the top level

Drop the duplicate invocation to AM_INIT_AUTOMAKE to solve this.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>