### PR TITLE
Fix './configure --without-system-libsafec' mistakenly enabling syste…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,7 +195,7 @@ AC_SUBST(SAFEC_STUB_DIR)
 AC_ARG_WITH(system-libsafec,
             AS_HELP_STRING([--with-system-libsafec],
                            [select to use libsafec installed in the system]),
-            [with_system_libsafec="yes"],
+            [],
             [with_system_libsafec="no"])
 
 AC_ARG_WITH([safec-dir],


### PR DESCRIPTION
…m-installed libsafec

The third argument to AC_ARG_WITH() is "action-if-given" [0]. That means that, when
calling ./configure --without-system-libsafec, the current code enables the option
instead of disabling it.

Just provide an empty argument to keep the proper value.

[0] https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#Package-Options