### PR TITLE
Enable TLS-only client authentication by default

### DIFF
--- a/example/client/README
+++ b/example/client/README
@@ -117,8 +117,7 @@ To run the example:
 5.  Optionally, you can use a certificate to identify the EST client
     to the server instead of specifying the HTTP user name/password.  
     Now that you've enrolled a certificate in step #3
-    above, you can use that certificate to enroll again. Note, your
-    EST server should be configured not to force HTTP authentication. 
+    above, you can use that certificate to enroll again.
 
     First, convert the pkcs7 cert from step 3 to a PEM cert:
 

--- a/example/server/estserver.c
+++ b/example/server/estserver.c
@@ -93,7 +93,6 @@ static int http_digest_auth = 0;
 static int http_basic_auth = 0;
 static int http_token_auth = 0;
 static int http_auth_disable = 0;
-static int disable_forced_http_auth = 0;
 static int enable_enhcd_cert_auth = 0;
 static int set_cert_auth_ah_pwd = 0;
 static EST_ECA_CSR_CHECK_FLAG enhcd_cert_csr_check_on = ECA_CSR_CHECK_OFF;
@@ -232,7 +231,6 @@ static void show_usage_and_exit (void)
             "  -t           Enable check for binding client PoP to the TLS UID\n"
             "  -m <seconds> Simulate manual CA enrollment\n"
             "  -n           Disable HTTP authentication (TLS client auth required)\n"
-            "  -o           Disable HTTP authentication when TLS client auth succeeds\n"
             "  -h           Use HTTP Digest auth instead of Basic auth\n"
             "  -b           Use HTTP Basic auth.  Causes explicit call to set Basic auth\n"
             "  -p <num>     TCP port number to listen on\n"
@@ -2244,9 +2242,6 @@ int main (int argc, char **argv)
         case 'n':
             http_auth_disable = 1;
             break;
-        case 'o':
-            disable_forced_http_auth = 1;
-            break;
         case 'v':
             verbose = 1;
             break;
@@ -2509,14 +2504,13 @@ int main (int argc, char **argv)
             exit(1);
         }
     }
-    if (disable_forced_http_auth) {
-        if (verbose)
-            printf(
-                "\nDisabling HTTP authentication when TLS client auth succeeds\n");
-        if (est_set_http_auth_required(ectx, HTTP_AUTH_NOT_REQUIRED)) {
-            printf("\nUnable to disable required HTTP auth.  Aborting!!!\n");
-            exit(1);
-        }
+
+    if (verbose)
+        printf(
+            "\nDisabling HTTP authentication when TLS client auth succeeds\n");
+    if (est_set_http_auth_required(ectx, HTTP_AUTH_NOT_REQUIRED)) {
+        printf("\nUnable to disable required HTTP auth.  Aborting!!!\n");
+        exit(1);
     }
 
     if (http_digest_auth) {

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver.sh
@@ -6,7 +6,7 @@ echo "Starting dt_start_estserver.sh ..."
 cd $WORKSPACE/example/server
 
 # this is the main estserver instance that should be used for simple enrolls
-$WORKSPACE/install/bin/estserver -o -p $EST_DT0_PORT1  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver    -p $EST_DT0_PORT1  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 1
 # the following estserver is set to reject the first attempted connection so we can test catching exceptions
 $WORKSPACE/install/bin/estserver    -p $EST_DT0_PORT2  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 -m 3600 &

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver1.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver1.sh
@@ -12,7 +12,7 @@ echo There are $# arguments to $0: $*
 echo first arguement will be used as the port number = $1
 
 # this is the main estserver instance that should be used for simple enrolls
-$WORKSPACE/install/bin/estserver -o -p $1  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver    -p $1  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 1
 # the following estserver is set to reject the first attempted connection so we can test catching exceptions
 $WORKSPACE/install/bin/estserver    -p $2  --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 -m 3600 &

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver2.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver2.sh
@@ -12,7 +12,7 @@ echo first arguement will be used as the port number = $1
 cd $WORKSPACE/example/server
 
 # this is the main estserver instance that should be used for simple reenrolls
-$WORKSPACE/install/bin/estserver -o -p $1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver -p $1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 3
 
 echo "dt_start_estserver2.sh is complete..."

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver3.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver3.sh
@@ -11,7 +11,7 @@ echo "Starting dt_start_estserver3.sh ..."
 cd $WORKSPACE/example/server
 
 # this is the main estserver instance that should be used for simple enrolls
-$WORKSPACE/install/bin/estserver -o -p $EST_CACERTS_PORT_NF --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver -p $EST_CACERTS_PORT_NF --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 3
 
 echo "dt_start_estserver3.sh is complete..."

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver4.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver4.sh
@@ -15,7 +15,7 @@ echo first arguement will be used as the port number = $1
 cd $WORKSPACE/example/server
 
 # this is the main estserver instance that should be used for simple reenrolls
-$WORKSPACE/install/bin/estserver -o -p $1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver -p $1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 3
 
 echo "dt_start_estserver4.sh is complete..."

--- a/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver5.sh
+++ b/java/src/com/cisco/c3m/est/test/DT/dt_start_estserver5.sh
@@ -11,7 +11,7 @@ echo "Starting dt_start_estserver5.sh ..."
 cd $WORKSPACE/example/server
 
 # this is the main estserver instance that should be used for simple reenrolls
-$WORKSPACE/install/bin/estserver -o -p $EST_DT5_PORT1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
+$WORKSPACE/install/bin/estserver -p $EST_DT5_PORT1 --srp passwd.srpv -c estCA/private/estservercertandkey.pem -k estCA/private/estservercertandkey.pem -r estrealm -v -6 -d 60 &
 sleep 3
 
 echo "dt_start_estserver5.sh is complete..."


### PR DESCRIPTION
Done to make _default_ builds of this EST server better conform to RFC 7030 that recommend TLS-based client authentication, whereas HTTP-based authentication is optional.

Extract from [RFC 7030 section 3.3.2. TLS-Based Client Authentication](https://www.rfc-editor.org/rfc/rfc7030.html#section-3.3.2): _TLS client authentication is the RECOMMENDED method for identifying EST clients.  HTTP-based client authentication (Section 3.2.3) MAY be used._
