### PR TITLE
est_ossl_util: add FIPS_mode{_set} stubs for compilation with OpenSSL 3

### DIFF
--- a/src/est/est_ossl_util.h
+++ b/src/est/est_ossl_util.h
@@ -28,6 +28,20 @@
 
 #include "est.h"
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+/**
+ * OpenSSL 3 removed FIPS_mode{_set} functions with
+ *   https://github.com/openssl/openssl/commit/31b069ecea2c567de22b3874c8e71cc37c921ec9
+ */
+static inline int FIPS_mode() {
+    return 0;
+}
+static inline int FIPS_mode_set(int r) {
+    (void)r;
+    return 1;
+}
+#endif
+
 /*
  * Indicate whether a pointer is to a cert or a csr
  */


### PR DESCRIPTION
OpenSSL 3 dropped FIPS_mode() and FIPS_mode_set() functions from the library via commit https://github.com/openssl/openssl/commit/31b069ecea2c567de22b3874c8e71cc37c921ec9

In our case, we don't use FIPS_mode(), nor the Java bindings to set FIPS_mode.
Inside the library, the FIPS_mode() function is used to do some sanity checks and not allow certain behavior.

For these cases, it is probably fine if we just stub these functions to return unsupported behavior. This still allows FIPS_mode to work with older OpenSSL libraries that still implement this feature.