### PR TITLE
RFC 8951 (an update to RFC 7030)

### DIFF
--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -472,7 +472,7 @@ static EST_ERROR verify_cacert_resp (EST_CTX *ctx, unsigned char *cacerts,
      * - convert to a PKCS7 structure,
      * - extract out the stack of certs.
      */
-    cacerts_decoded = malloc(*ca_certs_len);
+    cacerts_decoded = malloc(*cacerts_len);
     if (cacerts_decoded == NULL) {
         EST_LOG_ERR("Unable to allocate CA cert buffer for decode");
         return (EST_ERR_MALLOC);


### PR DESCRIPTION
In section 3.2.1 it clarifies that senders are not required to insert white space (such as LF) in base64-encoded payloads. Therefore libest must handle wrapped or unwrapped base64 with lines of any length.