### PR TITLE
Always include Content-Transfer-Encoding

### DIFF
--- a/src/est/est_client.c
+++ b/src/est/est_client.c
@@ -1422,6 +1422,7 @@ static int est_client_build_enroll_header (EST_CTX *ctx, char *hdr, int pkcs10_l
             "Host: %s:%d\r\n"
             "Accept: */*\r\n"
             "Content-Type: application/pkcs10\r\n"
+            "Content-Transfer-Encoding: base64\r\n"
             "Content-Length: %d\r\n",
             EST_PATH_PREFIX,
             (ctx->uri_path_segment?"/":""),
@@ -1463,6 +1464,7 @@ static int est_client_build_reenroll_header (EST_CTX *ctx, char *hdr, int pkcs10
             "Host: %s:%d\r\n"
             "Accept: */*\r\n"
             "Content-Type: application/pkcs10\r\n"
+            "Content-Transfer-Encoding: base64\r\n"
             "Content-Length: %d\r\n",
             EST_PATH_PREFIX,
             (ctx->uri_path_segment?"/":""),
@@ -1504,6 +1506,7 @@ static int est_client_build_server_keygen_header (EST_CTX *ctx, char *hdr, int p
             "Host: %s:%d\r\n"
             "Accept: */*\r\n"
             "Content-Type: application/pkcs10\r\n"
+            "Content-Transfer-Encoding: base64\r\n"
             "Content-Length: %d\r\n",
             EST_PATH_PREFIX,
             (ctx->uri_path_segment?"/":""),


### PR DESCRIPTION
* Content-Transfer-Encoding does not appear to be enforced in requests, only in responses [1]

* That said, it does appear in an *example* of client enrollment in the spec [2].

* Testing with server http://testrfc7030.com/ does not require Content-Transfer-Encoding in the request. Test server set up with globalsign/est [3] does require the header and will fail enrollment without it.

[1] https://datatracker.ietf.org/doc/html/rfc7030
[2] https://datatracker.ietf.org/doc/html/rfc7030#appendix-A.3
[3] https://github.com/globalsign/est